### PR TITLE
chore: switch to bundler module resolution and remove .js import suffixes

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,17 +1,17 @@
 import { Module, RequestMethod } from '@nestjs/common';
 import { ScheduleModule } from '@nestjs/schedule';
 import { LoggerModule } from 'nestjs-pino';
-import { AuditModule } from './audit/audit.module.js';
-import { ConfigModule } from './config/config.module.js';
-import { DatabaseModule } from './database/database.module.js';
-import { EvaluationModule } from './evaluation/evaluation.module.js';
-import { HealthModule } from './health/health.module.js';
-import { JellyfinModule } from './jellyfin/jellyfin.module.js';
-import { JellyseerrModule } from './jellyseerr/jellyseerr.module.js';
-import { MediaModule } from './media/media.module.js';
-import { RadarrModule } from './radarr/radarr.module.js';
-import { RulesModule } from './rules/rules.module.js';
-import { SonarrModule } from './sonarr/sonarr.module.js';
+import { AuditModule } from './audit/audit.module';
+import { ConfigModule } from './config/config.module';
+import { DatabaseModule } from './database/database.module';
+import { EvaluationModule } from './evaluation/evaluation.module';
+import { HealthModule } from './health/health.module';
+import { JellyfinModule } from './jellyfin/jellyfin.module';
+import { JellyseerrModule } from './jellyseerr/jellyseerr.module';
+import { MediaModule } from './media/media.module';
+import { RadarrModule } from './radarr/radarr.module';
+import { RulesModule } from './rules/rules.module';
+import { SonarrModule } from './sonarr/sonarr.module';
 
 @Module({
   imports: [

--- a/src/audit/audit.module.ts
+++ b/src/audit/audit.module.ts
@@ -1,5 +1,5 @@
 import { Global, Module } from '@nestjs/common';
-import { AuditService } from './audit.service.js';
+import { AuditService } from './audit.service';
 
 @Global()
 @Module({

--- a/src/audit/audit.service.test.ts
+++ b/src/audit/audit.service.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, mock, test } from 'bun:test';
-import type { ConfigService } from '../config/config.service.js';
-import { makeConfig, makeMovie, makeSeason } from '../test/index.js';
-import { AuditService } from './audit.service.js';
-import type { LogActionParams } from './audit.types.js';
+import type { ConfigService } from '../config/config.service';
+import { makeConfig, makeMovie, makeSeason } from '../test/index';
+import { AuditService } from './audit.service';
+import type { LogActionParams } from './audit.types';
 
 function makeLogActionParams(
   overrides: Partial<LogActionParams> = {},
@@ -139,7 +139,7 @@ describe('AuditService', () => {
       try {
         // Re-import to pick up mocked modules
         const { AuditService: MockedAuditService } = await import(
-          './audit.service.js'
+          './audit.service'
         );
 
         const configService = {

--- a/src/audit/audit.service.ts
+++ b/src/audit/audit.service.ts
@@ -6,8 +6,8 @@ import {
   type OnModuleInit,
 } from '@nestjs/common';
 import pino from 'pino';
-import { ConfigService } from '../config/config.service.js';
-import type { AuditEntry, LogActionParams } from './audit.types.js';
+import { ConfigService } from '../config/config.service';
+import type { AuditEntry, LogActionParams } from './audit.types';
 
 const AUDIT_LOG_DIR = '/config/logs/';
 

--- a/src/audit/audit.types.ts
+++ b/src/audit/audit.types.ts
@@ -1,5 +1,5 @@
-import type { Action } from '../config/config.schema.js';
-import type { UnifiedMedia } from '../shared/types.js';
+import type { Action } from '../config/config.schema';
+import type { UnifiedMedia } from '../shared/types';
 
 export interface LogActionParams {
   readonly item: UnifiedMedia;

--- a/src/audit/reasoning.test.ts
+++ b/src/audit/reasoning.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
-import type { ConditionGroup } from '../config/config.schema.js';
-import { buildReasoning } from './reasoning.js';
+import type { ConditionGroup } from '../config/config.schema';
+import { buildReasoning } from './reasoning';
 
 describe('buildReasoning', () => {
   test('formats a single leaf condition', () => {

--- a/src/audit/reasoning.ts
+++ b/src/audit/reasoning.ts
@@ -1,4 +1,4 @@
-import type { ConditionGroup } from '../config/config.schema.js';
+import type { ConditionGroup } from '../config/config.schema';
 
 /** Build a human-readable reasoning string from a condition tree. */
 export function buildReasoning(conditions: ConditionGroup): string {

--- a/src/config/config.module.ts
+++ b/src/config/config.module.ts
@@ -1,5 +1,5 @@
 import { Global, Module } from '@nestjs/common';
-import { ConfigService } from './config.service.js';
+import { ConfigService } from './config.service';
 
 @Global()
 @Module({

--- a/src/config/config.schema.ts
+++ b/src/config/config.schema.ts
@@ -5,7 +5,7 @@ import {
   getFieldDefinition,
   getServiceFromField,
   isOperatorCompatible,
-} from './field-registry.js';
+} from './field-registry';
 
 const serviceConfigSchema = z.object({
   base_url: z.url(),

--- a/src/config/config.service.test.ts
+++ b/src/config/config.service.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
-import { makeConfig, makeRule } from '../test/index.js';
-import { configSchema, validateConfig } from './config.schema.js';
+import { makeConfig, makeRule } from '../test/index';
+import { configSchema, validateConfig } from './config.schema';
 
 function validConfig(overrides: Record<string, any> = {}) {
   return {

--- a/src/config/config.service.ts
+++ b/src/config/config.service.ts
@@ -5,7 +5,7 @@ import {
   configSchema,
   type RoombarrConfig,
   validateConfig,
-} from './config.schema.js';
+} from './config.schema';
 
 const CONFIG_PATHS = [process.env.CONFIG_PATH, '/config/roombarr.yml'];
 

--- a/src/config/field-registry.test.ts
+++ b/src/config/field-registry.test.ts
@@ -5,7 +5,7 @@ import {
   getFieldDefinition,
   getServiceFromField,
   isOperatorCompatible,
-} from './field-registry.js';
+} from './field-registry';
 
 describe('fieldRegistry', () => {
   test('radarr registry fields match snapshot', () => {

--- a/src/database/database.module.ts
+++ b/src/database/database.module.ts
@@ -1,5 +1,5 @@
 import { Global, Module } from '@nestjs/common';
-import { DatabaseService } from './database.service.js';
+import { DatabaseService } from './database.service';
 
 @Global()
 @Module({

--- a/src/database/database.service.test.ts
+++ b/src/database/database.service.test.ts
@@ -2,9 +2,9 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { existsSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { mediaItems } from '../database/schema.js';
-import { createTestDatabase } from '../test/index.js';
-import { DatabaseService } from './database.service.js';
+import { mediaItems } from '../database/schema';
+import { createTestDatabase } from '../test/index';
+import { DatabaseService } from './database.service';
 
 describe('DatabaseService', () => {
   describe('initialization and schema', () => {

--- a/src/database/database.service.ts
+++ b/src/database/database.service.ts
@@ -10,7 +10,7 @@ import {
 } from '@nestjs/common';
 import { type BunSQLiteDatabase, drizzle } from 'drizzle-orm/bun-sqlite';
 import { migrate } from 'drizzle-orm/bun-sqlite/migrator';
-import * as schema from './schema.js';
+import * as schema from './schema';
 
 const DEFAULT_DB_PATH = '/config/roombarr.sqlite';
 

--- a/src/evaluation/evaluation.controller.test.ts
+++ b/src/evaluation/evaluation.controller.test.ts
@@ -2,9 +2,9 @@ import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
 import type { INestApplication } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
 import request from 'supertest';
-import { EvaluationController } from './evaluation.controller.js';
-import { EvaluationService } from './evaluation.service.js';
-import type { EvaluationRun } from './evaluation.types.js';
+import { EvaluationController } from './evaluation.controller';
+import { EvaluationService } from './evaluation.service';
+import type { EvaluationRun } from './evaluation.types';
 
 const runningRun: EvaluationRun = {
   run_id: 'run-001',

--- a/src/evaluation/evaluation.controller.ts
+++ b/src/evaluation/evaluation.controller.ts
@@ -9,7 +9,7 @@ import {
   Res,
 } from '@nestjs/common';
 import type { Response } from 'express';
-import { EvaluationService } from './evaluation.service.js';
+import { EvaluationService } from './evaluation.service';
 
 @Controller('evaluate')
 export class EvaluationController {

--- a/src/evaluation/evaluation.e2e.test.ts
+++ b/src/evaluation/evaluation.e2e.test.ts
@@ -1,21 +1,21 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
-import type { RuleConfig } from '../config/config.schema.js';
-import { getHydratedServices } from '../config/field-registry.js';
-import { ActionExecutorService } from '../execution/action-executor.service.js';
-import { MediaService } from '../media/media.service.js';
-import { RadarrClient } from '../radarr/radarr.client.js';
-import { RadarrService } from '../radarr/radarr.service.js';
-import { RulesService } from '../rules/rules.service.js';
-import type { EvaluationItemResult } from '../rules/types.js';
-import { SnapshotService } from '../snapshot/snapshot.service.js';
-import { StateService } from '../snapshot/state.service.js';
+import type { RuleConfig } from '../config/config.schema';
+import { getHydratedServices } from '../config/field-registry';
+import { ActionExecutorService } from '../execution/action-executor.service';
+import { MediaService } from '../media/media.service';
+import { RadarrClient } from '../radarr/radarr.client';
+import { RadarrService } from '../radarr/radarr.service';
+import { RulesService } from '../rules/rules.service';
+import type { EvaluationItemResult } from '../rules/types';
+import { SnapshotService } from '../snapshot/snapshot.service';
+import { StateService } from '../snapshot/state.service';
 import {
   createMockRadarrClient,
   createMockSonarrClient,
   makeRadarrMovie,
   makeRule,
   useTestDatabase,
-} from '../test/index.js';
+} from '../test/index';
 
 function createMockAuditService() {
   return { logAction: mock() };

--- a/src/evaluation/evaluation.module.ts
+++ b/src/evaluation/evaluation.module.ts
@@ -1,11 +1,11 @@
 import { Module } from '@nestjs/common';
-import { ConfigModule } from '../config/config.module.js';
-import { ExecutionModule } from '../execution/execution.module.js';
-import { MediaModule } from '../media/media.module.js';
-import { RulesModule } from '../rules/rules.module.js';
-import { SnapshotModule } from '../snapshot/snapshot.module.js';
-import { EvaluationController } from './evaluation.controller.js';
-import { EvaluationService } from './evaluation.service.js';
+import { ConfigModule } from '../config/config.module';
+import { ExecutionModule } from '../execution/execution.module';
+import { MediaModule } from '../media/media.module';
+import { RulesModule } from '../rules/rules.module';
+import { SnapshotModule } from '../snapshot/snapshot.module';
+import { EvaluationController } from './evaluation.controller';
+import { EvaluationService } from './evaluation.service';
 
 @Module({
   imports: [

--- a/src/evaluation/evaluation.service.test.ts
+++ b/src/evaluation/evaluation.service.test.ts
@@ -1,10 +1,7 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
-import type {
-  EvaluationItemResult,
-  EvaluationSummary,
-} from '../rules/types.js';
-import { makeConfig, makeMovie } from '../test/index.js';
-import { EvaluationService } from './evaluation.service.js';
+import type { EvaluationItemResult, EvaluationSummary } from '../rules/types';
+import { makeConfig, makeMovie } from '../test/index';
+import { EvaluationService } from './evaluation.service';
 
 const testConfig = makeConfig();
 

--- a/src/evaluation/evaluation.service.ts
+++ b/src/evaluation/evaluation.service.ts
@@ -1,14 +1,14 @@
 import { randomUUID } from 'node:crypto';
 import { Injectable, Logger } from '@nestjs/common';
 import { Cron, CronExpression } from '@nestjs/schedule';
-import { ConfigService } from '../config/config.service.js';
-import { getHydratedServices } from '../config/field-registry.js';
-import { ActionExecutorService } from '../execution/action-executor.service.js';
-import { MediaService } from '../media/media.service.js';
-import { RulesService } from '../rules/rules.service.js';
-import { SnapshotService } from '../snapshot/snapshot.service.js';
-import { StateService } from '../snapshot/state.service.js';
-import type { EvaluationRun } from './evaluation.types.js';
+import { ConfigService } from '../config/config.service';
+import { getHydratedServices } from '../config/field-registry';
+import { ActionExecutorService } from '../execution/action-executor.service';
+import { MediaService } from '../media/media.service';
+import { RulesService } from '../rules/rules.service';
+import { SnapshotService } from '../snapshot/snapshot.service';
+import { StateService } from '../snapshot/state.service';
+import type { EvaluationRun } from './evaluation.types';
 
 const MAX_STORED_RUNS = 10;
 

--- a/src/evaluation/evaluation.types.ts
+++ b/src/evaluation/evaluation.types.ts
@@ -1,7 +1,4 @@
-import type {
-  EvaluationItemResult,
-  EvaluationSummary,
-} from '../rules/types.js';
+import type { EvaluationItemResult, EvaluationSummary } from '../rules/types';
 
 export type EvaluationStatus = 'running' | 'completed' | 'failed';
 

--- a/src/execution/action-executor.service.test.ts
+++ b/src/execution/action-executor.service.test.ts
@@ -1,16 +1,16 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
 import { AxiosError } from 'axios';
-import type { RadarrClient } from '../radarr/radarr.client.js';
-import type { EvaluationItemResult } from '../rules/types.js';
-import { buildInternalId, type UnifiedMedia } from '../shared/types.js';
-import type { SonarrClient } from '../sonarr/sonarr.client.js';
+import type { RadarrClient } from '../radarr/radarr.client';
+import type { EvaluationItemResult } from '../rules/types';
+import { buildInternalId, type UnifiedMedia } from '../shared/types';
+import type { SonarrClient } from '../sonarr/sonarr.client';
 import {
   makeMovie,
   makeRadarrMovie,
   makeSeason,
   makeSonarrSeries,
-} from '../test/index.js';
-import { ActionExecutorService } from './action-executor.service.js';
+} from '../test/index';
+import { ActionExecutorService } from './action-executor.service';
 
 function makeResult(
   item: UnifiedMedia,

--- a/src/execution/action-executor.service.ts
+++ b/src/execution/action-executor.service.ts
@@ -1,16 +1,16 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { AxiosError } from 'axios';
-import type { Action } from '../config/config.schema.js';
-import { RadarrClient } from '../radarr/radarr.client.js';
-import type { EvaluationItemResult } from '../rules/types.js';
+import type { Action } from '../config/config.schema';
+import { RadarrClient } from '../radarr/radarr.client';
+import type { EvaluationItemResult } from '../rules/types';
 import {
   buildInternalId,
   type UnifiedMedia,
   type UnifiedMovie,
   type UnifiedSeason,
-} from '../shared/types.js';
-import { SonarrClient } from '../sonarr/sonarr.client.js';
-import type { ExecutionSummary } from './execution.types.js';
+} from '../shared/types';
+import { SonarrClient } from '../sonarr/sonarr.client';
+import type { ExecutionSummary } from './execution.types';
 
 @Injectable()
 export class ActionExecutorService {

--- a/src/execution/execution.module.ts
+++ b/src/execution/execution.module.ts
@@ -1,7 +1,7 @@
 import { Module } from '@nestjs/common';
-import { RadarrModule } from '../radarr/radarr.module.js';
-import { SonarrModule } from '../sonarr/sonarr.module.js';
-import { ActionExecutorService } from './action-executor.service.js';
+import { RadarrModule } from '../radarr/radarr.module';
+import { SonarrModule } from '../sonarr/sonarr.module';
+import { ActionExecutorService } from './action-executor.service';
 
 @Module({
   imports: [RadarrModule, SonarrModule],

--- a/src/execution/execution.types.ts
+++ b/src/execution/execution.types.ts
@@ -1,4 +1,4 @@
-import type { Action } from '../config/config.schema.js';
+import type { Action } from '../config/config.schema';
 
 export interface ExecutionSummary {
   actions_executed: Record<Action, number>;

--- a/src/health/health.controller.test.ts
+++ b/src/health/health.controller.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import type { INestApplication } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
 import request from 'supertest';
-import { HealthController } from './health.controller.js';
+import { HealthController } from './health.controller';
 
 describe('HealthController', () => {
   let app: INestApplication;

--- a/src/health/health.module.ts
+++ b/src/health/health.module.ts
@@ -1,5 +1,5 @@
 import { Module } from '@nestjs/common';
-import { HealthController } from './health.controller.js';
+import { HealthController } from './health.controller';
 
 @Module({
   controllers: [HealthController],

--- a/src/jellyfin/jellyfin.aggregator.test.ts
+++ b/src/jellyfin/jellyfin.aggregator.test.ts
@@ -4,7 +4,7 @@ import {
   aggregateSeasonWatchData,
   type UserSeasonEpisodeData,
   type UserWatchRecord,
-} from './jellyfin.aggregator.js';
+} from './jellyfin.aggregator';
 
 describe('aggregateMovieWatchData', () => {
   test('aggregates watch data from multiple users', () => {

--- a/src/jellyfin/jellyfin.aggregator.ts
+++ b/src/jellyfin/jellyfin.aggregator.ts
@@ -1,4 +1,4 @@
-import type { JellyfinData } from '../shared/types.js';
+import type { JellyfinData } from '../shared/types';
 
 /**
  * Per-user watch record for a single media item.

--- a/src/jellyfin/jellyfin.client.test.ts
+++ b/src/jellyfin/jellyfin.client.test.ts
@@ -6,9 +6,9 @@ import {
   axiosResponse,
   makeJellyfinItem,
   makeJellyfinUser,
-} from '../test/index.js';
-import { JellyfinClient } from './jellyfin.client.js';
-import type { JellyfinItemsResponse } from './jellyfin.types.js';
+} from '../test/index';
+import { JellyfinClient } from './jellyfin.client';
+import type { JellyfinItemsResponse } from './jellyfin.types';
 
 describe('JellyfinClient', () => {
   async function setup() {

--- a/src/jellyfin/jellyfin.client.ts
+++ b/src/jellyfin/jellyfin.client.ts
@@ -5,7 +5,7 @@ import type {
   JellyfinItem,
   JellyfinItemsResponse,
   JellyfinUser,
-} from './jellyfin.types.js';
+} from './jellyfin.types';
 
 @Injectable()
 export class JellyfinClient {

--- a/src/jellyfin/jellyfin.module.ts
+++ b/src/jellyfin/jellyfin.module.ts
@@ -1,8 +1,8 @@
 import { HttpModule } from '@nestjs/axios';
 import { Module } from '@nestjs/common';
-import { ConfigService } from '../config/config.service.js';
-import { JellyfinClient } from './jellyfin.client.js';
-import { JellyfinService } from './jellyfin.service.js';
+import { ConfigService } from '../config/config.service';
+import { JellyfinClient } from './jellyfin.client';
+import { JellyfinService } from './jellyfin.service';
 
 @Module({
   imports: [

--- a/src/jellyfin/jellyfin.service.test.ts
+++ b/src/jellyfin/jellyfin.service.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
-import { makeJellyfinItem, makeJellyfinUser } from '../test/index.js';
-import { JellyfinService, seasonKey } from './jellyfin.service.js';
+import { makeJellyfinItem, makeJellyfinUser } from '../test/index';
+import { JellyfinService, seasonKey } from './jellyfin.service';
 
 describe('JellyfinService', () => {
   let client: {

--- a/src/jellyfin/jellyfin.service.ts
+++ b/src/jellyfin/jellyfin.service.ts
@@ -1,14 +1,14 @@
 import { Injectable, Logger } from '@nestjs/common';
 import pLimit from 'p-limit';
-import type { JellyfinData } from '../shared/types.js';
+import type { JellyfinData } from '../shared/types';
 import {
   aggregateMovieWatchData,
   aggregateSeasonWatchData,
   type UserSeasonEpisodeData,
   type UserWatchRecord,
-} from './jellyfin.aggregator.js';
-import { JellyfinClient } from './jellyfin.client.js';
-import type { JellyfinItem, JellyfinUser } from './jellyfin.types.js';
+} from './jellyfin.aggregator';
+import { JellyfinClient } from './jellyfin.client';
+import type { JellyfinItem, JellyfinUser } from './jellyfin.types';
 
 /**
  * Identifies a Sonarr season for cross-referencing with Jellyfin.

--- a/src/jellyseerr/jellyseerr.client.test.ts
+++ b/src/jellyseerr/jellyseerr.client.test.ts
@@ -2,9 +2,9 @@ import { describe, expect, test } from 'bun:test';
 import { HttpModule, HttpService } from '@nestjs/axios';
 import { Test } from '@nestjs/testing';
 import { of } from 'rxjs';
-import { axiosResponse, makeJellyseerrRequest } from '../test/index.js';
-import { JellyseerrClient } from './jellyseerr.client.js';
-import type { JellyseerrRequestsResponse } from './jellyseerr.types.js';
+import { axiosResponse, makeJellyseerrRequest } from '../test/index';
+import { JellyseerrClient } from './jellyseerr.client';
+import type { JellyseerrRequestsResponse } from './jellyseerr.types';
 
 describe('JellyseerrClient', () => {
   async function setup() {

--- a/src/jellyseerr/jellyseerr.client.ts
+++ b/src/jellyseerr/jellyseerr.client.ts
@@ -4,7 +4,7 @@ import { firstValueFrom } from 'rxjs';
 import type {
   JellyseerrRequest,
   JellyseerrRequestsResponse,
-} from './jellyseerr.types.js';
+} from './jellyseerr.types';
 
 @Injectable()
 export class JellyseerrClient {

--- a/src/jellyseerr/jellyseerr.mapper.test.ts
+++ b/src/jellyseerr/jellyseerr.mapper.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
-import { makeJellyseerrRequest } from '../test/index.js';
-import { mapRequest } from './jellyseerr.mapper.js';
+import { makeJellyseerrRequest } from '../test/index';
+import { mapRequest } from './jellyseerr.mapper';
 
 describe('mapRequest', () => {
   test('maps approved request to JellyseerrData', () => {

--- a/src/jellyseerr/jellyseerr.mapper.ts
+++ b/src/jellyseerr/jellyseerr.mapper.ts
@@ -1,5 +1,5 @@
-import type { JellyseerrData } from '../shared/types.js';
-import type { JellyseerrRequest } from './jellyseerr.types.js';
+import type { JellyseerrData } from '../shared/types';
+import type { JellyseerrRequest } from './jellyseerr.types';
 
 /** Status codes from the Jellyseerr API. */
 const STATUS_LABELS: Record<number, string> = {

--- a/src/jellyseerr/jellyseerr.module.ts
+++ b/src/jellyseerr/jellyseerr.module.ts
@@ -1,8 +1,8 @@
 import { HttpModule } from '@nestjs/axios';
 import { Module } from '@nestjs/common';
-import { ConfigService } from '../config/config.service.js';
-import { JellyseerrClient } from './jellyseerr.client.js';
-import { JellyseerrService } from './jellyseerr.service.js';
+import { ConfigService } from '../config/config.service';
+import { JellyseerrClient } from './jellyseerr.client';
+import { JellyseerrService } from './jellyseerr.service';
 
 @Module({
   imports: [

--- a/src/jellyseerr/jellyseerr.service.test.ts
+++ b/src/jellyseerr/jellyseerr.service.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
-import { makeJellyseerrRequest } from '../test/index.js';
-import { JellyseerrService } from './jellyseerr.service.js';
+import { makeJellyseerrRequest } from '../test/index';
+import { JellyseerrService } from './jellyseerr.service';
 
 describe('JellyseerrService', () => {
   let client: { fetchAllRequests: ReturnType<typeof mock> };

--- a/src/jellyseerr/jellyseerr.service.ts
+++ b/src/jellyseerr/jellyseerr.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
-import type { JellyseerrData } from '../shared/types.js';
-import { JellyseerrClient } from './jellyseerr.client.js';
-import { mapRequest } from './jellyseerr.mapper.js';
+import type { JellyseerrData } from '../shared/types';
+import { JellyseerrClient } from './jellyseerr.client';
+import { mapRequest } from './jellyseerr.mapper';
 
 /**
  * Orchestrates Jellyseerr data fetching: retrieves all requests and

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,8 @@
 import { Logger as NestLogger } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { Logger } from 'nestjs-pino';
-import { AppModule } from './app.module.js';
-import { ConfigService } from './config/config.service.js';
+import { AppModule } from './app.module';
+import { ConfigService } from './config/config.service';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule, { bufferLogs: true });

--- a/src/media/media.integration.test.ts
+++ b/src/media/media.integration.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, mock, test } from 'bun:test';
-import type { RuleConfig } from '../config/config.schema.js';
-import { JellyfinService } from '../jellyfin/jellyfin.service.js';
-import type { JellyfinItem } from '../jellyfin/jellyfin.types.js';
-import { JellyseerrService } from '../jellyseerr/jellyseerr.service.js';
-import { RadarrService } from '../radarr/radarr.service.js';
-import type { UnifiedMovie, UnifiedSeason } from '../shared/types.js';
-import { SonarrService } from '../sonarr/sonarr.service.js';
+import type { RuleConfig } from '../config/config.schema';
+import { JellyfinService } from '../jellyfin/jellyfin.service';
+import type { JellyfinItem } from '../jellyfin/jellyfin.types';
+import { JellyseerrService } from '../jellyseerr/jellyseerr.service';
+import { RadarrService } from '../radarr/radarr.service';
+import type { UnifiedMovie, UnifiedSeason } from '../shared/types';
+import { SonarrService } from '../sonarr/sonarr.service';
 import {
   createMockJellyfinClient,
   createMockJellyseerrClient,
@@ -19,8 +19,8 @@ import {
   makeRule,
   makeSonarrSeries,
   makeSonarrTag,
-} from '../test/index.js';
-import { MediaService } from './media.service.js';
+} from '../test/index';
+import { MediaService } from './media.service';
 
 function makeMovieItem(overrides: Partial<JellyfinItem> = {}): JellyfinItem {
   return {

--- a/src/media/media.merger.test.ts
+++ b/src/media/media.merger.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, test } from 'bun:test';
-import type { JellyseerrIndexes } from '../jellyseerr/jellyseerr.service.js';
+import type { JellyseerrIndexes } from '../jellyseerr/jellyseerr.service';
 import {
   makeJellyfinData,
   makeJellyseerrData,
   makeMovie,
   makeSeason,
-} from '../test/index.js';
-import { enrichMovies, enrichSeasons } from './media.merger.js';
+} from '../test/index';
+import { enrichMovies, enrichSeasons } from './media.merger';
 
 const jellyfinData = makeJellyfinData({
   watched_by: ['alice', 'bob'],

--- a/src/media/media.merger.ts
+++ b/src/media/media.merger.ts
@@ -1,9 +1,9 @@
-import type { JellyseerrIndexes } from '../jellyseerr/jellyseerr.service.js';
+import type { JellyseerrIndexes } from '../jellyseerr/jellyseerr.service';
 import type {
   JellyfinData,
   UnifiedMovie,
   UnifiedSeason,
-} from '../shared/types.js';
+} from '../shared/types';
 
 /**
  * Enrich unified movies with Jellyfin and Jellyseerr data.

--- a/src/media/media.module.ts
+++ b/src/media/media.module.ts
@@ -1,14 +1,14 @@
 import { Module } from '@nestjs/common';
-import { ConfigService } from '../config/config.service.js';
-import { JellyfinModule } from '../jellyfin/jellyfin.module.js';
-import { JellyfinService } from '../jellyfin/jellyfin.service.js';
-import { JellyseerrModule } from '../jellyseerr/jellyseerr.module.js';
-import { JellyseerrService } from '../jellyseerr/jellyseerr.service.js';
-import { RadarrModule } from '../radarr/radarr.module.js';
-import { RadarrService } from '../radarr/radarr.service.js';
-import { SonarrModule } from '../sonarr/sonarr.module.js';
-import { SonarrService } from '../sonarr/sonarr.service.js';
-import { MediaService } from './media.service.js';
+import { ConfigService } from '../config/config.service';
+import { JellyfinModule } from '../jellyfin/jellyfin.module';
+import { JellyfinService } from '../jellyfin/jellyfin.service';
+import { JellyseerrModule } from '../jellyseerr/jellyseerr.module';
+import { JellyseerrService } from '../jellyseerr/jellyseerr.service';
+import { RadarrModule } from '../radarr/radarr.module';
+import { RadarrService } from '../radarr/radarr.service';
+import { SonarrModule } from '../sonarr/sonarr.module';
+import { SonarrService } from '../sonarr/sonarr.service';
+import { MediaService } from './media.service';
 
 /**
  * Orchestration module that imports all service modules and wires

--- a/src/media/media.service.test.ts
+++ b/src/media/media.service.test.ts
@@ -1,15 +1,15 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
-import type { RuleConfig } from '../config/config.schema.js';
-import type { JellyseerrIndexes } from '../jellyseerr/jellyseerr.service.js';
-import type { UnifiedMovie } from '../shared/types.js';
+import type { RuleConfig } from '../config/config.schema';
+import type { JellyseerrIndexes } from '../jellyseerr/jellyseerr.service';
+import type { UnifiedMovie } from '../shared/types';
 import {
   makeJellyfinData,
   makeJellyseerrData,
   makeMovie,
   makeRule,
   makeSeason,
-} from '../test/index.js';
-import { MediaService } from './media.service.js';
+} from '../test/index';
+import { MediaService } from './media.service';
 
 const jellyfinMovieData = makeJellyfinData({
   last_played: '2024-12-01T20:00:00Z',

--- a/src/media/media.service.ts
+++ b/src/media/media.service.ts
@@ -1,14 +1,14 @@
 import { Injectable, Logger } from '@nestjs/common';
-import type { Condition, RuleConfig } from '../config/config.schema.js';
-import { getServiceFromField } from '../config/field-registry.js';
-import type { SeasonIdentifier } from '../jellyfin/jellyfin.service.js';
-import { JellyfinService } from '../jellyfin/jellyfin.service.js';
-import type { JellyseerrIndexes } from '../jellyseerr/jellyseerr.service.js';
-import { JellyseerrService } from '../jellyseerr/jellyseerr.service.js';
-import { RadarrService } from '../radarr/radarr.service.js';
-import type { JellyfinData, UnifiedMedia } from '../shared/types.js';
-import { SonarrService } from '../sonarr/sonarr.service.js';
-import { enrichMovies, enrichSeasons } from './media.merger.js';
+import type { Condition, RuleConfig } from '../config/config.schema';
+import { getServiceFromField } from '../config/field-registry';
+import type { SeasonIdentifier } from '../jellyfin/jellyfin.service';
+import { JellyfinService } from '../jellyfin/jellyfin.service';
+import type { JellyseerrIndexes } from '../jellyseerr/jellyseerr.service';
+import { JellyseerrService } from '../jellyseerr/jellyseerr.service';
+import { RadarrService } from '../radarr/radarr.service';
+import type { JellyfinData, UnifiedMedia } from '../shared/types';
+import { SonarrService } from '../sonarr/sonarr.service';
+import { enrichMovies, enrichSeasons } from './media.merger';
 
 /**
  * Orchestrates data hydration from all configured services.

--- a/src/radarr/radarr.client.test.ts
+++ b/src/radarr/radarr.client.test.ts
@@ -7,8 +7,8 @@ import {
   makeRadarrImportListMovie,
   makeRadarrMovie,
   makeRadarrTag,
-} from '../test/index.js';
-import { RadarrClient } from './radarr.client.js';
+} from '../test/index';
+import { RadarrClient } from './radarr.client';
 
 describe('RadarrClient', () => {
   async function setup() {

--- a/src/radarr/radarr.client.ts
+++ b/src/radarr/radarr.client.ts
@@ -5,7 +5,7 @@ import type {
   RadarrImportListMovie,
   RadarrMovie,
   RadarrTag,
-} from './radarr.types.js';
+} from './radarr.types';
 
 @Injectable()
 export class RadarrClient {

--- a/src/radarr/radarr.mapper.test.ts
+++ b/src/radarr/radarr.mapper.test.ts
@@ -3,13 +3,13 @@ import {
   makeRadarrImportListMovie,
   makeRadarrMovie,
   makeRadarrTag,
-} from '../test/index.js';
+} from '../test/index';
 import {
   buildImportListIndex,
   buildTagMap,
   mapMovie,
   resolveTagNames,
-} from './radarr.mapper.js';
+} from './radarr.mapper';
 
 const TAGS = [
   makeRadarrTag({ id: 1, label: 'keep-forever' }),

--- a/src/radarr/radarr.mapper.ts
+++ b/src/radarr/radarr.mapper.ts
@@ -1,9 +1,9 @@
-import type { RadarrData } from '../shared/types.js';
+import type { RadarrData } from '../shared/types';
 import type {
   RadarrImportListMovie,
   RadarrMovie,
   RadarrTag,
-} from './radarr.types.js';
+} from './radarr.types';
 
 /**
  * Build a tag ID → name lookup map from the Radarr tag list.

--- a/src/radarr/radarr.module.ts
+++ b/src/radarr/radarr.module.ts
@@ -1,8 +1,8 @@
 import { HttpModule } from '@nestjs/axios';
 import { Module } from '@nestjs/common';
-import { ConfigService } from '../config/config.service.js';
-import { RadarrClient } from './radarr.client.js';
-import { RadarrService } from './radarr.service.js';
+import { ConfigService } from '../config/config.service';
+import { RadarrClient } from './radarr.client';
+import { RadarrService } from './radarr.service';
 
 @Module({
   imports: [

--- a/src/radarr/radarr.service.test.ts
+++ b/src/radarr/radarr.service.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
-import { makeRadarrMovie } from '../test/index.js';
-import { RadarrService } from './radarr.service.js';
-import type { RadarrImportListMovie, RadarrTag } from './radarr.types.js';
+import { makeRadarrMovie } from '../test/index';
+import { RadarrService } from './radarr.service';
+import type { RadarrImportListMovie, RadarrTag } from './radarr.types';
 
 describe('RadarrService', () => {
   let client: {

--- a/src/radarr/radarr.service.ts
+++ b/src/radarr/radarr.service.ts
@@ -1,11 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
-import type { UnifiedMovie } from '../shared/types.js';
-import { RadarrClient } from './radarr.client.js';
-import {
-  buildImportListIndex,
-  buildTagMap,
-  mapMovie,
-} from './radarr.mapper.js';
+import type { UnifiedMovie } from '../shared/types';
+import { RadarrClient } from './radarr.client';
+import { buildImportListIndex, buildTagMap, mapMovie } from './radarr.mapper';
 
 /**
  * Orchestrates Radarr data fetching: retrieves all movies and tags,

--- a/src/rules/field-resolver.test.ts
+++ b/src/rules/field-resolver.test.ts
@@ -4,8 +4,8 @@ import {
   makeJellyseerrData,
   makeMovie,
   makeSeason,
-} from '../test/index.js';
-import { resolveField } from './field-resolver.js';
+} from '../test/index';
+import { resolveField } from './field-resolver';
 
 const jellyfinData = makeJellyfinData({
   watched_by: ['Alice', 'Bob'],

--- a/src/rules/field-resolver.ts
+++ b/src/rules/field-resolver.ts
@@ -1,4 +1,4 @@
-import type { UnifiedMedia } from '../shared/types.js';
+import type { UnifiedMedia } from '../shared/types';
 
 /**
  * Resolves a dotted field path (e.g., "radarr.size_on_disk" or

--- a/src/rules/operators.test.ts
+++ b/src/rules/operators.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
-import { operators } from './operators.js';
+import { operators } from './operators';
 
 describe('operators', () => {
   describe('equals', () => {

--- a/src/rules/rules.module.ts
+++ b/src/rules/rules.module.ts
@@ -1,5 +1,5 @@
 import { Module } from '@nestjs/common';
-import { RulesService } from './rules.service.js';
+import { RulesService } from './rules.service';
 
 @Module({
   providers: [RulesService],

--- a/src/rules/rules.service.test.ts
+++ b/src/rules/rules.service.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, test } from 'bun:test';
-import type { AuditService } from '../audit/audit.service.js';
-import type { RuleConfig } from '../config/config.schema.js';
-import type { UnifiedMedia } from '../shared/types.js';
-import { makeMovie, makeSeason } from '../test/index.js';
-import { RulesService } from './rules.service.js';
+import type { AuditService } from '../audit/audit.service';
+import type { RuleConfig } from '../config/config.schema';
+import type { UnifiedMedia } from '../shared/types';
+import { makeMovie, makeSeason } from '../test/index';
+import { RulesService } from './rules.service';
 
 const mockAuditService = {
   logAction: () => {},

--- a/src/rules/rules.service.ts
+++ b/src/rules/rules.service.ts
@@ -1,16 +1,16 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { AuditService } from '../audit/audit.service.js';
-import { buildReasoning } from '../audit/reasoning.js';
+import { AuditService } from '../audit/audit.service';
+import { buildReasoning } from '../audit/reasoning';
 import type {
   Condition,
   ConditionGroup,
   LeafCondition,
   RoombarrConfig,
-} from '../config/config.schema.js';
-import { getServiceFromField } from '../config/field-registry.js';
-import { buildInternalId, type UnifiedMedia } from '../shared/types.js';
-import { resolveField } from './field-resolver.js';
-import { operators } from './operators.js';
+} from '../config/config.schema';
+import { getServiceFromField } from '../config/field-registry';
+import { buildInternalId, type UnifiedMedia } from '../shared/types';
+import { resolveField } from './field-resolver';
+import { operators } from './operators';
 import {
   ACTION_PRIORITY,
   type Action,
@@ -18,7 +18,7 @@ import {
   type EvaluationSummary,
   type RuleConfig,
   type RuleMatch,
-} from './types.js';
+} from './types';
 
 @Injectable()
 export class RulesService {

--- a/src/rules/types.ts
+++ b/src/rules/types.ts
@@ -2,7 +2,7 @@ import type {
   Action,
   ConditionGroup,
   RuleConfig,
-} from '../config/config.schema.js';
+} from '../config/config.schema';
 export type { Action, ConditionGroup, RuleConfig };
 
 export type ExecutionStatus = 'success' | 'failed' | 'skipped' | 'not_found';

--- a/src/snapshot/snapshot-state.integration.test.ts
+++ b/src/snapshot/snapshot-state.integration.test.ts
@@ -1,10 +1,10 @@
 import { beforeEach, describe, expect, test } from 'bun:test';
 import { and, eq, sql } from 'drizzle-orm';
-import { fieldChanges } from '../database/schema.js';
-import type { UnifiedMedia, UnifiedMovie } from '../shared/types.js';
-import { makeMovie, useTestDatabase } from '../test/index.js';
-import { SnapshotService } from './snapshot.service.js';
-import { StateService } from './state.service.js';
+import { fieldChanges } from '../database/schema';
+import type { UnifiedMedia, UnifiedMovie } from '../shared/types';
+import { makeMovie, useTestDatabase } from '../test/index';
+import { SnapshotService } from './snapshot.service';
+import { StateService } from './state.service';
 
 describe('Snapshot → State integration', () => {
   const db = useTestDatabase();

--- a/src/snapshot/snapshot.module.ts
+++ b/src/snapshot/snapshot.module.ts
@@ -1,6 +1,6 @@
 import { Module } from '@nestjs/common';
-import { SnapshotService } from './snapshot.service.js';
-import { StateService } from './state.service.js';
+import { SnapshotService } from './snapshot.service';
+import { StateService } from './state.service';
 
 @Module({
   providers: [SnapshotService, StateService],

--- a/src/snapshot/snapshot.service.test.ts
+++ b/src/snapshot/snapshot.service.test.ts
@@ -1,8 +1,8 @@
 import { beforeEach, describe, expect, test } from 'bun:test';
 import { count, eq, like } from 'drizzle-orm';
-import { fieldChanges, mediaItems } from '../database/schema.js';
-import { makeJellyfinData, makeMovie, useTestDatabase } from '../test/index.js';
-import { SnapshotService } from './snapshot.service.js';
+import { fieldChanges, mediaItems } from '../database/schema';
+import { makeJellyfinData, makeMovie, useTestDatabase } from '../test/index';
+import { SnapshotService } from './snapshot.service';
 
 describe('SnapshotService', () => {
   const db = useTestDatabase();

--- a/src/snapshot/snapshot.service.ts
+++ b/src/snapshot/snapshot.service.ts
@@ -2,12 +2,12 @@ import { Injectable, Logger } from '@nestjs/common';
 import { gt, sql } from 'drizzle-orm';
 import type { BunSQLiteDatabase } from 'drizzle-orm/bun-sqlite';
 import diff from 'microdiff';
-import { fieldRegistry } from '../config/field-registry.js';
-import { DatabaseService } from '../database/database.service.js';
-import type * as schema from '../database/schema.js';
-import { fieldChanges, mediaItems } from '../database/schema.js';
-import { resolveField } from '../rules/field-resolver.js';
-import type { UnifiedMedia } from '../shared/types.js';
+import { fieldRegistry } from '../config/field-registry';
+import { DatabaseService } from '../database/database.service';
+import type * as schema from '../database/schema';
+import { fieldChanges, mediaItems } from '../database/schema';
+import { resolveField } from '../rules/field-resolver';
+import type { UnifiedMedia } from '../shared/types';
 
 /** Row shape returned from loading media_items. */
 interface SnapshotRow {

--- a/src/snapshot/state-registry.test.ts
+++ b/src/snapshot/state-registry.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { stateFieldRegistry } from './state-registry.js';
+import { stateFieldRegistry } from './state-registry';
 
 describe('stateFieldRegistry', () => {
   test('has exactly 2 entries', () => {

--- a/src/snapshot/state.service.test.ts
+++ b/src/snapshot/state.service.test.ts
@@ -1,10 +1,10 @@
 import { beforeEach, describe, expect, test } from 'bun:test';
 import { and, eq, sql } from 'drizzle-orm';
-import { fieldChanges } from '../database/schema.js';
-import type { UnifiedMovie, UnifiedSeason } from '../shared/types.js';
-import { makeMovie, makeSeason, useTestDatabase } from '../test/index.js';
-import { SnapshotService } from './snapshot.service.js';
-import { StateService } from './state.service.js';
+import { fieldChanges } from '../database/schema';
+import type { UnifiedMovie, UnifiedSeason } from '../shared/types';
+import { makeMovie, makeSeason, useTestDatabase } from '../test/index';
+import { SnapshotService } from './snapshot.service';
+import { StateService } from './state.service';
 
 describe('StateService', () => {
   const db = useTestDatabase();

--- a/src/snapshot/state.service.ts
+++ b/src/snapshot/state.service.ts
@@ -1,15 +1,12 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { inArray, sql } from 'drizzle-orm';
 import type { BunSQLiteDatabase } from 'drizzle-orm/bun-sqlite';
-import { DatabaseService } from '../database/database.service.js';
-import type * as schema from '../database/schema.js';
-import { fieldChanges, mediaItems } from '../database/schema.js';
-import { resolveField } from '../rules/field-resolver.js';
-import type { StateData, UnifiedMedia } from '../shared/types.js';
-import {
-  type StateFieldPattern,
-  stateFieldRegistry,
-} from './state-registry.js';
+import { DatabaseService } from '../database/database.service';
+import type * as schema from '../database/schema';
+import { fieldChanges, mediaItems } from '../database/schema';
+import { resolveField } from '../rules/field-resolver';
+import type { StateData, UnifiedMedia } from '../shared/types';
+import { type StateFieldPattern, stateFieldRegistry } from './state-registry';
 
 interface FieldChangeRow {
   mediaType: string;

--- a/src/sonarr/sonarr.client.test.ts
+++ b/src/sonarr/sonarr.client.test.ts
@@ -7,8 +7,8 @@ import {
   makeSonarrEpisodeFile,
   makeSonarrSeries,
   makeSonarrTag,
-} from '../test/index.js';
-import { SonarrClient } from './sonarr.client.js';
+} from '../test/index';
+import { SonarrClient } from './sonarr.client';
 
 describe('SonarrClient', () => {
   async function setup() {

--- a/src/sonarr/sonarr.client.ts
+++ b/src/sonarr/sonarr.client.ts
@@ -5,7 +5,7 @@ import type {
   SonarrEpisodeFile,
   SonarrSeries,
   SonarrTag,
-} from './sonarr.types.js';
+} from './sonarr.types';
 
 @Injectable()
 export class SonarrClient {

--- a/src/sonarr/sonarr.mapper.test.ts
+++ b/src/sonarr/sonarr.mapper.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'bun:test';
-import { makeSonarrSeries, makeSonarrTag } from '../test/index.js';
-import { buildTagMap, mapSeason, resolveTagNames } from './sonarr.mapper.js';
-import type { SonarrSeason } from './sonarr.types.js';
+import { makeSonarrSeries, makeSonarrTag } from '../test/index';
+import { buildTagMap, mapSeason, resolveTagNames } from './sonarr.mapper';
+import type { SonarrSeason } from './sonarr.types';
 
 const TAGS = [
   makeSonarrTag({ id: 1, label: 'keep-forever' }),

--- a/src/sonarr/sonarr.mapper.ts
+++ b/src/sonarr/sonarr.mapper.ts
@@ -1,5 +1,5 @@
-import type { SonarrData } from '../shared/types.js';
-import type { SonarrSeason, SonarrSeries, SonarrTag } from './sonarr.types.js';
+import type { SonarrData } from '../shared/types';
+import type { SonarrSeason, SonarrSeries, SonarrTag } from './sonarr.types';
 
 /**
  * Build a tag ID → name lookup map from the Sonarr tag list.

--- a/src/sonarr/sonarr.module.ts
+++ b/src/sonarr/sonarr.module.ts
@@ -1,8 +1,8 @@
 import { HttpModule } from '@nestjs/axios';
 import { Module } from '@nestjs/common';
-import { ConfigService } from '../config/config.service.js';
-import { SonarrClient } from './sonarr.client.js';
-import { SonarrService } from './sonarr.service.js';
+import { ConfigService } from '../config/config.service';
+import { SonarrClient } from './sonarr.client';
+import { SonarrService } from './sonarr.service';
 
 @Module({
   imports: [

--- a/src/sonarr/sonarr.service.test.ts
+++ b/src/sonarr/sonarr.service.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
-import { makeSonarrSeries } from '../test/index.js';
-import { SonarrService } from './sonarr.service.js';
-import type { SonarrTag } from './sonarr.types.js';
+import { makeSonarrSeries } from '../test/index';
+import { SonarrService } from './sonarr.service';
+import type { SonarrTag } from './sonarr.types';
 
 describe('SonarrService', () => {
   let client: {

--- a/src/sonarr/sonarr.service.ts
+++ b/src/sonarr/sonarr.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
-import type { UnifiedSeason } from '../shared/types.js';
-import { SonarrClient } from './sonarr.client.js';
-import { buildTagMap, mapSeason } from './sonarr.mapper.js';
+import type { UnifiedSeason } from '../shared/types';
+import { SonarrClient } from './sonarr.client';
+import { buildTagMap, mapSeason } from './sonarr.mapper';
 
 /**
  * Orchestrates Sonarr data fetching: retrieves all series and tags,

--- a/src/test/api-fixtures.ts
+++ b/src/test/api-fixtures.ts
@@ -1,15 +1,15 @@
-import type { JellyfinItem, JellyfinUser } from '../jellyfin/jellyfin.types.js';
-import type { JellyseerrRequest } from '../jellyseerr/jellyseerr.types.js';
+import type { JellyfinItem, JellyfinUser } from '../jellyfin/jellyfin.types';
+import type { JellyseerrRequest } from '../jellyseerr/jellyseerr.types';
 import type {
   RadarrImportListMovie,
   RadarrMovie,
   RadarrTag,
-} from '../radarr/radarr.types.js';
+} from '../radarr/radarr.types';
 import type {
   SonarrEpisodeFile,
   SonarrSeries,
   SonarrTag,
-} from '../sonarr/sonarr.types.js';
+} from '../sonarr/sonarr.types';
 
 /** Creates a `RadarrMovie` with sensible defaults for testing. */
 export function makeRadarrMovie(

--- a/src/test/database.ts
+++ b/src/test/database.ts
@@ -3,7 +3,7 @@ import { randomUUID } from 'node:crypto';
 import { existsSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { DatabaseService } from '../database/database.service.js';
+import { DatabaseService } from '../database/database.service';
 
 interface TestDatabase {
   dbService: DatabaseService;

--- a/src/test/fixtures.ts
+++ b/src/test/fixtures.ts
@@ -1,4 +1,4 @@
-import type { RoombarrConfig, RuleConfig } from '../config/config.schema.js';
+import type { RoombarrConfig, RuleConfig } from '../config/config.schema';
 import type {
   JellyfinData,
   JellyseerrData,
@@ -6,7 +6,7 @@ import type {
   SonarrData,
   UnifiedMovie,
   UnifiedSeason,
-} from '../shared/types.js';
+} from '../shared/types';
 
 /** Override type for `makeMovie` — allows partial radarr sub-object merging. */
 export type MovieOverrides = Partial<

--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -8,9 +8,9 @@ export {
   makeSonarrEpisodeFile,
   makeSonarrSeries,
   makeSonarrTag,
-} from './api-fixtures.js';
-export { createTestDatabase, useTestDatabase } from './database.js';
-export type { MovieOverrides, SeasonOverrides } from './fixtures.js';
+} from './api-fixtures';
+export { createTestDatabase, useTestDatabase } from './database';
+export type { MovieOverrides, SeasonOverrides } from './fixtures';
 export {
   makeConfig,
   makeJellyfinData,
@@ -18,11 +18,11 @@ export {
   makeMovie,
   makeRule,
   makeSeason,
-} from './fixtures.js';
-export { axiosResponse } from './http.js';
+} from './fixtures';
+export { axiosResponse } from './http';
 export {
   createMockJellyfinClient,
   createMockJellyseerrClient,
   createMockRadarrClient,
   createMockSonarrClient,
-} from './mocks.js';
+} from './mocks';

--- a/src/test/mocks.ts
+++ b/src/test/mocks.ts
@@ -1,20 +1,20 @@
 import { mock } from 'bun:test';
-import type { JellyfinClient } from '../jellyfin/jellyfin.client.js';
-import type { JellyfinItem, JellyfinUser } from '../jellyfin/jellyfin.types.js';
-import type { JellyseerrClient } from '../jellyseerr/jellyseerr.client.js';
-import type { JellyseerrRequest } from '../jellyseerr/jellyseerr.types.js';
-import type { RadarrClient } from '../radarr/radarr.client.js';
+import type { JellyfinClient } from '../jellyfin/jellyfin.client';
+import type { JellyfinItem, JellyfinUser } from '../jellyfin/jellyfin.types';
+import type { JellyseerrClient } from '../jellyseerr/jellyseerr.client';
+import type { JellyseerrRequest } from '../jellyseerr/jellyseerr.types';
+import type { RadarrClient } from '../radarr/radarr.client';
 import type {
   RadarrImportListMovie,
   RadarrMovie,
   RadarrTag,
-} from '../radarr/radarr.types.js';
-import type { SonarrClient } from '../sonarr/sonarr.client.js';
+} from '../radarr/radarr.types';
+import type { SonarrClient } from '../sonarr/sonarr.client';
 import type {
   SonarrEpisodeFile,
   SonarrSeries,
   SonarrTag,
-} from '../sonarr/sonarr.types.js';
+} from '../sonarr/sonarr.types';
 
 /** Creates a mock `RadarrClient` with all methods stubbed. */
 export function createMockRadarrClient() {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "module": "nodenext",
-    "moduleResolution": "nodenext",
+    "module": "preserve",
+    "moduleResolution": "bundler",
     "resolvePackageJsonExports": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,


### PR DESCRIPTION
## Summary

- Switches `moduleResolution` from `nodenext` to `bundler` and `module` from `nodenext` to `preserve` in `tsconfig.json`
- Removes all 259 `.js` suffixes from relative imports across 82 source files
- Aligns TypeScript configuration with Bun's actual module resolution behavior

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] `bun run test` passes (414 tests, 0 failures)
- [x] `bun run build` compiles successfully

Closes #29