### PR TITLE
refactor: remove deprecated getDatabase() and migrate raw SQL to Drizzle

### DIFF
--- a/src/database/database.service.test.ts
+++ b/src/database/database.service.test.ts
@@ -2,7 +2,8 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { existsSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { mediaItems } from '../database/schema';
+import { and, eq, sql } from 'drizzle-orm';
+import { fieldChanges, mediaItems } from '../database/schema';
 import { createTestDatabase } from '../test/index';
 import { DatabaseService } from './database.service';
 
@@ -19,107 +20,83 @@ describe('DatabaseService', () => {
 
     afterEach(() => cleanup());
 
-    test('provides access to the underlying database', () => {
-      const db = service.getDatabase();
-      expect(db).toBeTruthy();
-    });
-
     test('sets WAL journal mode', () => {
-      const db = service.getDatabase();
+      const db = service.getDrizzle();
 
-      const result = db
-        .query<{ journal_mode: string }, []>('PRAGMA journal_mode')
-        .get();
-      expect(result!.journal_mode).toBe('wal');
+      const [result] = db.all<{ journal_mode: string }>(
+        sql`PRAGMA journal_mode`,
+      );
+      expect(result.journal_mode).toBe('wal');
     });
 
     test('enables foreign keys', () => {
-      const db = service.getDatabase();
+      const db = service.getDrizzle();
 
-      const result = db
-        .query<{ foreign_keys: number }, []>('PRAGMA foreign_keys')
-        .get();
-      expect(result!.foreign_keys).toBe(1);
+      const [result] = db.all<{ foreign_keys: number }>(
+        sql`PRAGMA foreign_keys`,
+      );
+      expect(result.foreign_keys).toBe(1);
     });
 
     test('sets synchronous to NORMAL', () => {
-      const db = service.getDatabase();
+      const db = service.getDrizzle();
 
-      const result = db
-        .query<{ synchronous: number }, []>('PRAGMA synchronous')
-        .get();
+      const [result] = db.all<{ synchronous: number }>(sql`PRAGMA synchronous`);
       // synchronous=NORMAL is 1
-      expect(result!.synchronous).toBe(1);
-    });
-
-    test('creates media_items table via Drizzle migration', () => {
-      const db = service.getDatabase();
-
-      const table = db
-        .query<{ name: string }, [string]>(
-          "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
-        )
-        .get('media_items');
-      expect(table).toBeTruthy();
-    });
-
-    test('creates field_changes table with FK', () => {
-      const db = service.getDatabase();
-
-      const table = db
-        .query<{ name: string }, [string]>(
-          "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
-        )
-        .get('field_changes');
-      expect(table).toBeTruthy();
+      expect(result.synchronous).toBe(1);
     });
 
     test('creates idx_field_changes_state index', () => {
-      const db = service.getDatabase();
+      const db = service.getDrizzle();
 
-      const idx = db
-        .query<{ name: string }, [string]>(
-          "SELECT name FROM sqlite_master WHERE type='index' AND name=?",
-        )
-        .get('idx_field_changes_state');
+      const [idx] = db.all<{ name: string }>(
+        sql`SELECT name FROM sqlite_master WHERE type='index' AND name='idx_field_changes_state'`,
+      );
       expect(idx).toBeTruthy();
     });
 
-    test('exposes Drizzle instance via getDrizzle()', () => {
-      const drizzleDb = service.getDrizzle();
-
-      expect(drizzleDb).toBeTruthy();
-      const rows = drizzleDb.select().from(mediaItems).all();
-      expect(rows).toBeDefined();
-      expect(rows.length).toBeGreaterThanOrEqual(0);
-    });
-
     test('FK cascade deletes field_changes when media_item is deleted', () => {
-      const db = service.getDatabase();
+      const db = service.getDrizzle();
+      const now = new Date().toISOString();
 
       // Insert a media item
-      db.query(
-        `INSERT INTO media_items (media_type, media_id, title, data, data_hash, first_seen_at, last_seen_at)
-       VALUES (?, ?, ?, ?, ?, datetime('now'), datetime('now'))`,
-      ).run('movie', '1', 'Test', '{}', 'hash');
+      db.insert(mediaItems)
+        .values({
+          mediaType: 'movie',
+          mediaId: '1',
+          title: 'Test',
+          data: '{}',
+          dataHash: 'hash',
+          firstSeenAt: now,
+          lastSeenAt: now,
+        })
+        .run();
 
       // Insert a field change referencing it
-      db.query(
-        `INSERT INTO field_changes (media_type, media_id, field_path, old_value, new_value, changed_at)
-       VALUES (?, ?, ?, ?, ?, datetime('now'))`,
-      ).run('movie', '1', 'radarr.monitored', 'true', 'false');
+      db.insert(fieldChanges)
+        .values({
+          mediaType: 'movie',
+          mediaId: '1',
+          fieldPath: 'radarr.monitored',
+          oldValue: 'true',
+          newValue: 'false',
+          changedAt: now,
+        })
+        .run();
 
       // Delete the media item
-      db.query(
-        'DELETE FROM media_items WHERE media_type = ? AND media_id = ?',
-      ).run('movie', '1');
+      db.delete(mediaItems)
+        .where(
+          and(eq(mediaItems.mediaType, 'movie'), eq(mediaItems.mediaId, '1')),
+        )
+        .run();
 
       // Field change should be cascade-deleted
       const changes = db
-        .query<{ id: number }, [string]>(
-          'SELECT id FROM field_changes WHERE media_id = ?',
-        )
-        .all('1');
+        .select()
+        .from(fieldChanges)
+        .where(eq(fieldChanges.mediaId, '1'))
+        .all();
       expect(changes).toHaveLength(0);
     });
   });
@@ -148,27 +125,35 @@ describe('DatabaseService', () => {
 
     test('does not re-run migrations on second init', () => {
       service.onModuleInit();
-      const db = service.getDatabase();
+      const db = service.getDrizzle();
+      const now = new Date().toISOString();
 
       // Insert a test row
-      db.query(
-        `INSERT INTO media_items (media_type, media_id, title, data, data_hash, first_seen_at, last_seen_at)
-       VALUES (?, ?, ?, ?, ?, datetime('now'), datetime('now'))`,
-      ).run('movie', '1', 'Test', '{}', 'hash');
+      db.insert(mediaItems)
+        .values({
+          mediaType: 'movie',
+          mediaId: '1',
+          title: 'Test',
+          data: '{}',
+          dataHash: 'hash',
+          firstSeenAt: now,
+          lastSeenAt: now,
+        })
+        .run();
 
       service.onModuleDestroy();
 
       // Re-init
       service = new DatabaseService(dbPath);
       service.onModuleInit();
-      const db2 = service.getDatabase();
+      const db2 = service.getDrizzle();
 
       // Data should still be there
       const row = db2
-        .query<{ title: string }, [string]>(
-          'SELECT title FROM media_items WHERE media_id = ?',
-        )
-        .get('1');
+        .select({ title: mediaItems.title })
+        .from(mediaItems)
+        .where(eq(mediaItems.mediaId, '1'))
+        .get();
       expect(row!.title).toBe('Test');
     });
 
@@ -178,7 +163,7 @@ describe('DatabaseService', () => {
 
       // Accessing the DB after close should throw
       expect(() => {
-        service.getDatabase().query('SELECT 1').get();
+        service.getDrizzle().select().from(mediaItems).all();
       }).toThrow();
     });
   });

--- a/src/database/database.service.ts
+++ b/src/database/database.service.ts
@@ -64,14 +64,6 @@ export class DatabaseService implements OnModuleInit, OnModuleDestroy {
     return this.drizzleDb;
   }
 
-  /**
-   * Expose the raw Database instance for services that need direct access.
-   * @deprecated Migrate consumers to getDrizzle() — will be removed in Phase 5.
-   */
-  getDatabase(): Database {
-    return this.db;
-  }
-
   private configurePragmas() {
     this.db.exec('PRAGMA foreign_keys = ON');
     this.db.exec('PRAGMA journal_mode = WAL');

--- a/src/snapshot/snapshot.service.test.ts
+++ b/src/snapshot/snapshot.service.test.ts
@@ -77,6 +77,22 @@ describe('SnapshotService', () => {
     expect(changes).toHaveLength(0);
   });
 
+  test('does not increment missed_evaluations for seen-but-unchanged items', async () => {
+    const movie = makeMovie();
+
+    // First snapshot
+    await snapshotService.snapshot([movie], new Set(['radarr']));
+
+    // Same movie again — unchanged
+    await snapshotService.snapshot([movie], new Set(['radarr']));
+
+    const row = db.drizzle
+      .select({ missedEvaluations: mediaItems.missedEvaluations })
+      .from(mediaItems)
+      .get();
+    expect(row!.missedEvaluations).toBe(0);
+  });
+
   test('only snapshots fields for hydrated services', async () => {
     const movie = makeMovie({
       jellyfin: makeJellyfinData(),

--- a/src/snapshot/snapshot.service.ts
+++ b/src/snapshot/snapshot.service.ts
@@ -133,18 +133,16 @@ export class SnapshotService {
 
       // Content hash skip — if unchanged, just reset missed_evaluations
       if (existing.dataHash === dataHash) {
-        if (existing.missedEvaluations > 0) {
-          upserts.push({
-            mediaType,
-            mediaId,
-            title: item.title,
-            data: existing.data,
-            dataHash: existing.dataHash,
-            firstSeenAt: now,
-            lastSeenAt: now,
-            isNew: false,
-          });
-        }
+        upserts.push({
+          mediaType,
+          mediaId,
+          title: item.title,
+          data: existing.data,
+          dataHash: existing.dataHash,
+          firstSeenAt: now,
+          lastSeenAt: now,
+          isNew: false,
+        });
         continue;
       }
 

--- a/src/snapshot/snapshot.service.ts
+++ b/src/snapshot/snapshot.service.ts
@@ -238,6 +238,13 @@ export class SnapshotService {
 
     // Step 4: Execute all writes in a single transaction
     await db.transaction(async tx => {
+      // Bulk-increment missed_evaluations for all existing rows.
+      // Current items will be reset to 0 by the upserts that follow.
+      // New items don't exist yet, so they're unaffected.
+      await tx
+        .update(mediaItems)
+        .set({ missedEvaluations: sql`${mediaItems.missedEvaluations} + 1` });
+
       // Upsert media items in chunks
       for (const batch of chunk(upserts, MEDIA_ITEMS_CHUNK_SIZE)) {
         await tx
@@ -261,7 +268,7 @@ export class SnapshotService {
               data: sql`excluded.data`,
               dataHash: sql`excluded.data_hash`,
               lastSeenAt: sql`excluded.last_seen_at`,
-              missedEvaluations: sql`0`,
+              missedEvaluations: 0,
             },
           });
       }
@@ -279,9 +286,6 @@ export class SnapshotService {
           })),
         );
       }
-
-      // Increment missed_evaluations for items not seen this cycle
-      await this.incrementMissedEvaluations(tx, currentIds);
     });
 
     this.logger.log(
@@ -369,34 +373,6 @@ export class SnapshotService {
       map.set(`${row.mediaType}:${row.mediaId}`, row);
     }
     return map;
-  }
-
-  /** Increment missed_evaluations for all items not in the current set. */
-  private async incrementMissedEvaluations(
-    tx: BunSQLiteDatabase<typeof schema>,
-    currentIds: Set<string>,
-  ): Promise<void> {
-    const allRows = tx
-      .select({
-        mediaType: mediaItems.mediaType,
-        mediaId: mediaItems.mediaId,
-      })
-      .from(mediaItems)
-      .all();
-
-    for (const row of allRows) {
-      const key = `${row.mediaType}:${row.mediaId}`;
-      if (!currentIds.has(key)) {
-        await tx
-          .update(mediaItems)
-          .set({
-            missedEvaluations: sql`${mediaItems.missedEvaluations} + 1`,
-          })
-          .where(
-            sql`${mediaItems.mediaType} = ${row.mediaType} AND ${mediaItems.mediaId} = ${row.mediaId}`,
-          );
-      }
-    }
   }
 
   /** Delete snapshots that have been missing for more than the grace period. */

--- a/src/snapshot/state.service.ts
+++ b/src/snapshot/state.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { inArray, sql } from 'drizzle-orm';
+import { inArray } from 'drizzle-orm';
 import type { BunSQLiteDatabase } from 'drizzle-orm/bun-sqlite';
 import { DatabaseService } from '../database/database.service';
 import type * as schema from '../database/schema';
@@ -43,19 +43,22 @@ export class StateService {
   enrich(items: UnifiedMedia[]): UnifiedMedia[] {
     const db = this.getDb();
 
-    // Check if any snapshots exist — if not, this is the first evaluation
-    const result = db
-      .select({ count: sql<number>`count(*)` })
+    // Batch-load all media item keys for existence checks in computeState
+    const allMediaItems = db
+      .select({ mediaType: mediaItems.mediaType, mediaId: mediaItems.mediaId })
       .from(mediaItems)
-      .get();
-    const snapshotCount = result?.count ?? 0;
+      .all();
 
-    if (snapshotCount === 0) {
+    if (allMediaItems.length === 0) {
       this.logger.debug(
         'No snapshots exist yet (first evaluation), skipping state enrichment',
       );
       return items;
     }
+
+    const snapshotKeys = new Set(
+      allMediaItems.map(row => `${row.mediaType}:${row.mediaId}`),
+    );
 
     // Collect all tracked field paths for the items in this batch
     const targetTypes = new Set(
@@ -93,6 +96,7 @@ export class StateService {
         compositeKey,
         relevantEntries,
         changeIndex,
+        snapshotKeys,
       );
 
       return { ...item, state };
@@ -137,21 +141,14 @@ export class StateService {
     compositeKey: string,
     entries: Array<[string, StateFieldPattern]>,
     changeIndex: Map<string, Map<string, FieldChangeRow[]>>,
+    snapshotKeys: Set<string>,
   ): StateData | null {
-    const db = this.getDb();
-
     // Check if this item has been snapshotted before
     const mediaType = item.type === 'movie' ? 'movie' : 'season';
     const mediaId = compositeKey.split(':')[1];
-    const snapshot = db
-      .select({ mediaId: mediaItems.mediaId })
-      .from(mediaItems)
-      .where(
-        sql`${mediaItems.mediaType} = ${mediaType} AND ${mediaItems.mediaId} = ${mediaId}`,
-      )
-      .get();
-
-    if (!snapshot) return null;
+    if (!snapshotKeys.has(`${mediaType}:${mediaId}`)) {
+      return null;
+    }
 
     const itemChanges = changeIndex.get(compositeKey);
     const result: Record<string, unknown> = {};


### PR DESCRIPTION
## Summary
- Remove the deprecated `getDatabase()` method from `DatabaseService`, completing the Drizzle ORM migration
- Migrate all remaining raw SQL queries in tests to use Drizzle's query builder API
- Replace O(N) per-item `UPDATE` queries in `incrementMissedEvaluations` with a single bulk `UPDATE` + upsert reset pattern
- Replace O(N) per-item `SELECT` queries in `StateService.computeState` with a batch-loaded `Set` for O(1) in-memory existence checks
- Remove 3 redundant tests that provided no unique coverage beyond existing tests

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] `bun run test` passes (410 tests, down from 413 after removing 3 redundant tests)
- [ ] Verify orphan cleanup still works correctly (missed evaluations increment for absent items, reset to 0 for present items)
- [ ] Verify state enrichment skips items without existing snapshots

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed missed evaluation counter to correctly track unseen items and prevent incrementing for unchanged content that's been recently seen.

* **Refactor**
  * Improved internal database access patterns and optimized snapshot existence checks for better performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->